### PR TITLE
[WIP] Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
   skip_cleanup: true
   region: "eu-central-1"
   local_dir: "build"
-  upload-dir: "phar"
+  upload-dir: "phar/test"
   acl: "public-read"
   on:
-    branch: master
+    branch: fix-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
   skip_cleanup: true
   region: "eu-central-1"
   local_dir: "build"
-  upload-dir: "phar/test"
+  upload-dir: "phar"
   acl: "public-read"
   on:
-    branch: fix-build
+    branch: master

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     "phar-builder": {
       "compression": "GZip",
       "name": "behat-standalone.phar",
-      "output-dir": "./build",
-      "entry-point": "./vendor/behat/behat/bin/behat",
+      "output-dir": "build",
+      "entry-point": "vendor/bin/behat",
       "include-dev": false,
       "include" : [],
       "skip-shebang" : false

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
       "compression": "GZip",
       "name": "behat-standalone.phar",
       "output-dir": "./build",
-      "entry-point": "./vendor/bin/behat",
+      "entry-point": "./vendor/behat/behat/bin/behat",
       "include-dev": false,
       "include" : [],
       "skip-shebang" : false


### PR DESCRIPTION
fixed entry point to behat. With the old entry, there was always the message that dependencies had to be installed.

#### Before:
<img width="929" alt="the phar from s3-bucket before change" src="https://user-images.githubusercontent.com/12425528/39087423-fed1e966-45a0-11e8-98c1-4582e503594b.png">

#### After:
<img width="972" alt="phar from s3-bucket after the change" src="https://user-images.githubusercontent.com/12425528/39087427-14a3dff6-45a1-11e8-895d-0edebf9ba331.png">

I created a test phar in a subfolder of the s3-bucket phar/test/

I think the path-variables for the PharBuilder are handled differently on macOs and linux, because locally the old values worked fine, but the produced phar by travis was build wrong.
